### PR TITLE
chore: update entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@delight-labs/aegis-js",
   "license": "MIT",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "scripts": {
     "build": "tsc && vite build",
     "prepare": "husky",


### PR DESCRIPTION
currently, when a CJS project using `aegis-js` (or old webpack wants to bundle it), it will use `main` (which points to ESM `.js`) instead of the correct CJS entry (`.cjs` file).

---

### in old webpack (4 or below) 
- for CJS: `main`
- for ESM: `module`

ref: https://github.com/webpack/webpack/issues/5756#issuecomment-335220617, [react-bootstrap](https://github.com/react-bootstrap/react-bootstrap/blob/b16b833a22f6a74784e410c1facb09629875ea35/package.json#L28-L29), https://nodejs.org/api/packages.html#main


### in vite and current webpack
- for CJS: `exports.require`
- for ESM: `exports.import`

ref: https://v2.vitejs.dev/config/#resolve-conditions, https://webpack.js.org/guides/package-exports/


